### PR TITLE
Fixed bug on downloading multiple files:

### DIFF
--- a/src/main/java/io/meltwin/scyblaster/common/resources/ResourceLoader.java
+++ b/src/main/java/io/meltwin/scyblaster/common/resources/ResourceLoader.java
@@ -35,10 +35,10 @@ public interface ResourceLoader extends Logging {
 
         // Try to download all the files
         UnavailableResourceException exception = null;
+        FutureCluster<ResourceFile> fileCluster = ResourceHandler.prepareFiles(fileList);
         fileList = new ArrayList<>();
         try {
             long start = System.nanoTime();
-            FutureCluster<ResourceFile> fileCluster = ResourceHandler.prepareFiles(fileList);
             for (Future<ResourceFile> fut : fileCluster) {
                 if (exception != null) {
                     fut.cancel(true);


### PR DESCRIPTION
Caused by:
Deleting ArrayList contents before sending it to the ResourceHandler.

Fixed by:
Swapping the order of the two operations.