### PR TITLE
ProjectConfiguration doesn't load the version range / type correctly

### DIFF
--- a/src/main/java/io/meltwin/scyblaster/config/DTOMinecraft.java
+++ b/src/main/java/io/meltwin/scyblaster/config/DTOMinecraft.java
@@ -9,32 +9,26 @@ import org.jetbrains.annotations.NotNull;
 import io.meltwin.scyblaster.common.types.Pair;
 
 class DTOMinecraft {
-    /*
-     * ========================================================================
-     * Version Type
-     * ========================================================================
-     */
-    private VersionType type = VersionType.ALL;
 
-    @XmlAttribute(name = "type", required = true)
-    public void setType(String type) {
-        this.type = VersionType.fromValue(type);
-    }
+    // ========================================================================
+    // Version Type
+    // ========================================================================
+    private VersionType versionType = VersionType.ALL;
 
+    @XmlAttribute(name = "type")
+    @XmlJavaTypeAdapter(VersionTypeAdapter.class)
     public void setType(VersionType type) {
-        this.type = type;
+        this.versionType = type;
     }
 
     @NotNull
     public VersionType getType() {
-        return type;
+        return versionType;
     }
 
-    /*
-     * ========================================================================
-     * Online authentification
-     * ========================================================================
-     */
+    // ========================================================================
+    // Online authentification
+    // ========================================================================
     private boolean isOnline = true;
 
     @XmlAttribute(name = "online", required = true)
@@ -47,11 +41,9 @@ class DTOMinecraft {
         return this.isOnline;
     }
 
-    /*
-     * ========================================================================
-     * Version Range
-     * ========================================================================
-     */
+    // ========================================================================
+    // Version Range
+    // ========================================================================
     private Pair<String, String> versions = new Pair<>("", "");
 
     @XmlAttribute(name = "version")
@@ -65,12 +57,9 @@ class DTOMinecraft {
         return versions;
     }
 
-    /*
-     * ========================================================================
-     * Demo
-     * ========================================================================
-     */
-
+    // ========================================================================
+    // Demo
+    // ========================================================================
     private boolean _isDemo = false;
 
     @XmlElement(name = "isDemo")
@@ -82,11 +71,9 @@ class DTOMinecraft {
         return this._isDemo;
     }
 
-    /*
-     * ========================================================================
-     * QuickPlay (Multiplayer)
-     * ========================================================================
-     */
+    // ========================================================================
+    // QuickPlay (Multiplayer)
+    // ========================================================================
     private String _quickplayM = null;
 
     @XmlElement(name = "quickplay-online")
@@ -98,11 +85,9 @@ class DTOMinecraft {
         return this._quickplayM;
     }
 
-    /*
-     * ========================================================================
-     * QuickPlay (Singleplayer)
-     * ========================================================================
-     */
+    // ========================================================================
+    // QuickPlay (Singleplayer)
+    // ========================================================================
     private String _quickplayS = null;
 
     @XmlElement(name = "quickplay-single")
@@ -114,11 +99,9 @@ class DTOMinecraft {
         return this._quickplayS;
     }
 
-    /*
-     * ========================================================================
-     * QuickPlay (Realms)
-     * ========================================================================
-     */
+    // ========================================================================
+    // QuickPlay (Realms)
+    // ========================================================================
     private String _quickplayR = null;
 
     @XmlElement(name = "quickplay-realms")

--- a/src/main/java/io/meltwin/scyblaster/config/ProjectConfiguration.java
+++ b/src/main/java/io/meltwin/scyblaster/config/ProjectConfiguration.java
@@ -269,7 +269,7 @@ public class ProjectConfiguration implements Logging, Serializable {
                 String.format(DEBUG_NATIVES, getNativesDirName(), getNativesPath()));
         builder.append(
                 String.format(DEBUG_VERSION, getVersionsDirName(), getVersionsPath()));
-        builder.append(String.format(DEBUG_ALLOWED_VERSION, getAllowedMCVersionNumber(),
+        builder.append(String.format(DEBUG_ALLOWED_VERSION, getAllowedMCVersionNumber().toString(),
                 getAllowedMCVersions().getFirst(), getAllowedMCVersions().getSecond()));
         builder.append(String.format(DEBUG_IS_DEMO, isInDemoMode()));
         builder.append(String.format(DEBUG_IS_ONLINE, isOnline()));

--- a/src/main/java/io/meltwin/scyblaster/config/ProjectConfiguration.java
+++ b/src/main/java/io/meltwin/scyblaster/config/ProjectConfiguration.java
@@ -71,14 +71,12 @@ public class ProjectConfiguration implements Logging, Serializable {
      *                jar achive.
      */
     public ProjectConfiguration(@NotNull String pkgfile) {
-        try {
-            InputStream istream = getClass().getClassLoader().getResourceAsStream(pkgfile);
+        try (InputStream istream = getClass().getClassLoader().getResourceAsStream(pkgfile)) {
             if (istream == null) {
                 log().fatal(String.format("File %s doesn't exist inside the jar archive !", pkgfile));
                 System.exit(-1);
             }
             fromInputStream(istream);
-            istream.close();
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -256,6 +254,7 @@ public class ProjectConfiguration implements Logging, Serializable {
     static final String DEBUG_VERSION = "\tVERSION: %1$-16s - %2$s\n";
     static final String DEBUG_ALLOWED_VERSION = "\n\tMC Versions: %1$s | %2$s -> %3$s\n";
     static final String DEBUG_IS_DEMO = "\tDemo Mode : %b\n";
+    static final String DEBUG_IS_ONLINE = "\tOnline : %b\n";
     static final String DEBUG_QUICKPLAY = "\n\tQuickplay:\n\t\tSingleplayer: %1$s\n\t\tMultiplayer: %2$s\n\t\tRealms: %3$s\n";
 
     static final String DEBUG_ENDPOINTS = "\n\tEndpoints roots:\n\t\tMANIFEST: %1$s\n\t\tASSETS:   %2$s";
@@ -273,6 +272,7 @@ public class ProjectConfiguration implements Logging, Serializable {
         builder.append(String.format(DEBUG_ALLOWED_VERSION, getAllowedMCVersionNumber(),
                 getAllowedMCVersions().getFirst(), getAllowedMCVersions().getSecond()));
         builder.append(String.format(DEBUG_IS_DEMO, isInDemoMode()));
+        builder.append(String.format(DEBUG_IS_ONLINE, isOnline()));
         builder.append(String.format(DEBUG_QUICKPLAY, getQuickplaySingleplayer(), getQuickplayMultiplayer(),
                 getQuickplayRealms()));
         builder.append(String.format(DEBUG_ENDPOINTS, getVersionsManifestEndpoints(), getAssetsRootEndpoints()));

--- a/src/main/java/io/meltwin/scyblaster/config/VersionAdapter.java
+++ b/src/main/java/io/meltwin/scyblaster/config/VersionAdapter.java
@@ -15,20 +15,12 @@ class VersionAdapter extends XmlAdapter<String, Pair<String, String>> implements
     @Override
     public Pair<String, String> unmarshal(String version) throws Exception {
         String[] parts = version.split("->");
-        // Logging unmarshal
-        ftrace("Unmarshalling version: %s", version);
-        for (String s : parts) {
-            ftrace("\t %s", s);
-        }
 
         // Export
         Pair<String, String> out = new Pair<>("", "");
         if (parts.length >= 2) {
             out.setFirst(parts[0]);
             out.setSecond(parts[1]);
-
-            // if (out.getSecond() < out.getFirst())
-            // out.setSecond(out.getFirst());
         } else {
             out.setFirst(version);
             out.setSecond(out.getFirst());

--- a/src/main/java/io/meltwin/scyblaster/config/VersionAdapter.java
+++ b/src/main/java/io/meltwin/scyblaster/config/VersionAdapter.java
@@ -2,9 +2,10 @@ package io.meltwin.scyblaster.config;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
+import io.meltwin.scyblaster.common.types.Logging;
 import io.meltwin.scyblaster.common.types.Pair;
 
-class VersionAdapter extends XmlAdapter<String, Pair<String, String>> {
+class VersionAdapter extends XmlAdapter<String, Pair<String, String>> implements Logging {
 
     @Override
     public String marshal(Pair<String, String> v) throws Exception {
@@ -13,7 +14,14 @@ class VersionAdapter extends XmlAdapter<String, Pair<String, String>> {
 
     @Override
     public Pair<String, String> unmarshal(String version) throws Exception {
-        String[] parts = version.split("|");
+        String[] parts = version.split("->");
+        // Logging unmarshal
+        ftrace("Unmarshalling version: %s", version);
+        for (String s : parts) {
+            ftrace("\t %s", s);
+        }
+
+        // Export
         Pair<String, String> out = new Pair<>("", "");
         if (parts.length >= 2) {
             out.setFirst(parts[0]);

--- a/src/main/java/io/meltwin/scyblaster/config/VersionTypeAdapter.java
+++ b/src/main/java/io/meltwin/scyblaster/config/VersionTypeAdapter.java
@@ -1,0 +1,25 @@
+package io.meltwin.scyblaster.config;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import io.meltwin.scyblaster.common.types.Logging;
+
+class VersionTypeAdapter extends XmlAdapter<String, VersionType> implements Logging {
+
+    @Override
+    public String marshal(VersionType v) throws Exception {
+        return v.toString();
+    }
+
+    @Override
+    public VersionType unmarshal(String v) throws Exception {
+        try {
+            return VersionType.fromValue(v.toUpperCase());
+        } catch (Exception e) {
+            fwarn("The value %s is invalid for the version type !", v);
+            e.printStackTrace();
+        }
+        return VersionType.RANGE;
+
+    }
+}

--- a/src/main/resources/project.xml
+++ b/src/main/resources/project.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
     <resources base-dir=".scyblaster">
+        <assets>sc-assets</assets>
+        <libs>sc-libs</libs>
+        <versions>sc-versions</versions>
+        <natives>sc-natives</natives>
     </resources>
-    <minecraft type="single" version="1.20.1">
+    <minecraft type="single" version="1.20.1" online="false">
+        <isDemo>true</isDemo>
+        <quickplay-online>mc.scyblaster.net</quickplay-online>
+        <quickplay-single>single</quickplay-single>
+        <quickplay-realms>reamls.scyblaster.net</quickplay-realms>
     </minecraft>
+    <endpoints>
+        <versions>https://piston-meta.mojang.com/mc/game/version_manifest_v2.json</versions>
+        <assets>https://resources.download.minecraft.net/</assets>
+    </endpoints>
 </project>


### PR DESCRIPTION
Changed:
---

- **Version range**: String.split() seems to split every char when the splitting character isn't found
   -  Changed to an arrow "->" splitting sequence
- **Version type**: Hidden exception on enum casting. Couldn't cast lowercase String to Enum.
   - Casting to an Enum after making it an uppercase String 